### PR TITLE
Fixes SystemInterface becoming nil when loading SystemBasedTests

### DIFF
--- a/source/BaselineOfKepler/BaselineOfKepler.class.st
+++ b/source/BaselineOfKepler/BaselineOfKepler.class.st
@@ -38,7 +38,7 @@ BaselineOfKepler >> baseline: spec [
 { #category : #actions }
 BaselineOfKepler >> preload: aLoader package: aPackageSpec [
 
-	Smalltalk at: #SystemInterface put: nil.
+	Smalltalk at: #SystemInterface ifAbsentPut: nil.
 
 
 ]
@@ -64,7 +64,7 @@ BaselineOfKepler >> registerInterfaceAs: aKey named: aName declaring: aSelectorS
 { #category : #actions }
 BaselineOfKepler >> registerSystemInterfaces [
 
-	SystemInterface := Namespace new.
+	SystemInterface ifNil: [ SystemInterface := Namespace new ].
 	
 	self
 		registerTimeSystemInterface;


### PR DESCRIPTION
When using:
```smalltalk
spec
	project: 'KeplerDevelopmentSupport'
	copyFrom: 'Kepler'
	with: [ spec loads: 'SystemBasedTests' ]
```
It breaks because it reinitializes the SystemInterface Namespace, doing a nil check before that to avoid the problem.