### PR TITLE
Reset dependencies cache before resolving all subsystem dependencies.

### DIFF
--- a/source/BaselineOfKepler/BaselineOfKepler.class.st
+++ b/source/BaselineOfKepler/BaselineOfKepler.class.st
@@ -35,7 +35,7 @@ BaselineOfKepler >> baselineKepler: spec [
 		group: 'Dependent-SUnit-Extensions' with: 'Kepler-SUnit-Model'.
 
 	spec
-		package: 'Kepler-System-Tests' with: [ spec requires: 'Core' ];
+		package: 'Kepler-System-Tests' with: [ spec requires: #('Core' 'Buoy-SUnit') ];
 		group: 'Tests' with: 'Kepler-System-Tests';
 		package: 'Kepler-Time-Tests' with: [ spec requires: 'Kepler-Time' ];
 		group: 'Tests' with: 'Kepler-Time-Tests';

--- a/source/Kepler-System-Tests/CompositeSystemTest.class.st
+++ b/source/Kepler-System-Tests/CompositeSystemTest.class.st
@@ -17,10 +17,10 @@ CompositeSystemTest >> testCannotRegisterAnAlreadyStartedSystem [
 		startUp.
 
 	self
-		assert: (composite >> #CustomerManagementSystem) isStarted;
+		assert: ( composite >> #CustomerManagementSystem ) isStarted;
 		should: [ CompositeSystem new register: composite >> #CustomerManagementSystem ]
 			raise: SystemControlError
-			withExceptionDo: [ :error | self assert: error messageText equals: 'Cannot register a subsystem not stopped (CMS)' ]
+			withMessageText: 'Cannot register a subsystem not stopped (CMS)'
 ]
 
 { #category : #tests }
@@ -97,7 +97,7 @@ CompositeSystemTest >> testGettingSystemImplementingInterface [
 	self
 		should: [ system >> #ProjectManagementSystem ]
 		raise: SystemControlError
-		withExceptionDo: [ :error | self assert: error messageText equals: 'System implementing "Project Management" not found.' ]
+		withMessageText: 'System implementing "Project Management" not found.'
 ]
 
 { #category : #tests }
@@ -182,7 +182,7 @@ CompositeSystemTest >> testSendingMessagesToSystemWithUnresolvedSystemDependency
 	self
 		should: [ system >> #ProjectManagementSystem addProjectNamed: 'Fail' for: 'Pedro' ]
 		raise: SystemControlError
-		withExceptionDo: [ :error | self assert: error messageText equals: 'Unresolved system dependency to "Customer Querying"' ]
+		withMessageText: 'Unresolved system dependency to "Customer Querying"'
 ]
 
 { #category : #tests }
@@ -219,7 +219,7 @@ CompositeSystemTest >> testSystemMissingDependenciesWillNotStart [
 	self
 		should: [ composite startUp ]
 		raise: SystemControlError
-		withExceptionDo: [ :error | self assert: error messageText equals: 'System implementing "Customer Querying" not found.' ]
+		withMessageText: 'System implementing "Customer Querying" not found.'
 ]
 
 { #category : #tests }
@@ -253,5 +253,5 @@ CompositeSystemTest >> testWontStartWhenRequiredSystemNotFound [
 	self
 		should: [ system startUp ]
 		raise: SystemControlError
-		withExceptionDo: [ :error | self assert: error messageText equals: 'System implementing "Customer Querying" not found.' ]
+		withMessageText: 'System implementing "Customer Querying" not found.'
 ]

--- a/source/Kepler-System-Tests/SystemHotSwapperTest.class.st
+++ b/source/Kepler-System-Tests/SystemHotSwapperTest.class.st
@@ -23,7 +23,7 @@ SystemHotSwapperTest >> testCantSwapWhenTheInterfaceIsNotImplemented [
 	self
 		should: [ (SystemHotSwapper swapSystemImplementing: #CustomerManagementSystem with: newCMS) applyTo: composite ]
 		raise: SystemControlError
-		withExceptionDo: [ :error | self assert: error messageText equals: 'CMS is not implementing Customer Management' ]
+		withMessageText: 'CMS is not implementing Customer Management'
 ]
 
 { #category : #tests }
@@ -52,4 +52,33 @@ SystemHotSwapperTest >> testSwapping [
 	self
 		assert: composite >> #CustomerQueryingSystem equals: newCMS;
 		assert: (composite >> #CustomerQueryingSystem) customers size equals: 2
+]
+
+{ #category : #tests }
+SystemHotSwapperTest >> testSwappingSystemWithDependents [
+
+	| composite cms newCMS pms |
+
+	cms := SampleCustomerSystem new.
+	pms := SampleProjectSystem new.
+	composite := CompositeSystem new
+		register: cms;
+		register: pms;
+		yourself.
+	composite startUp.
+
+	newCMS := FixedCustomerSystem new.
+
+	self deny: cms = newCMS.
+
+	self
+		assert: composite >> #CustomerQueryingSystem equals: cms;
+		assert: pms >> #CustomerQueryingSystem equals: cms.
+
+	( SystemHotSwapper swapSystemImplementing: #CustomerQueryingSystem with: newCMS )
+		applyTo: composite.
+
+	self
+		assert: composite >> #CustomerQueryingSystem equals: newCMS;
+		assert: pms >> #CustomerQueryingSystem equals: newCMS
 ]

--- a/source/Kepler-System/SubsystemImplementation.class.st
+++ b/source/Kepler-System/SubsystemImplementation.class.st
@@ -93,7 +93,9 @@ SubsystemImplementation >> resetDependencies [
 { #category : #installing }
 SubsystemImplementation >> resolveDependencies [
 
-	self dependencies do: [ :interfaceKey | dependencies bind: interfaceKey to: self parent >> interfaceKey ]
+	self resetDependencies.
+	self dependencies
+		do: [ :interfaceKey | dependencies bind: interfaceKey to: self parent >> interfaceKey ]
 ]
 
 { #category : #'private - controlling' }


### PR DESCRIPTION
Fixes #36
Reset dependencies cache before resolving all subsystem dependencies.
Improve tests using Buoy-SUnit extensions.